### PR TITLE
use require-pr pass output

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -23,9 +23,6 @@ jobs:
   publish-to-test-pypi:
     runs-on: ubuntu-latest
     steps:
-      - uses: rayepps/require-push-to-pr@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v1
       - name: Set up Python 3.8
         uses: actions/setup-python@v1
@@ -37,6 +34,11 @@ jobs:
           pip install -r requirements.dev.txt
       - name: Build a binary wheel and a source tarball
         run: make create-dist
+      - uses: rayepps/require-push-to-pr@v1
+        id: 'require_push'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish distribution 📦 to Test PyPI
+        if: steps.require_push.outputs.pass == 'true'
         run: >
           make test-upload-dist token=${{ secrets.test_pypi_token }}

--- a/oapispec/version.py
+++ b/oapispec/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.0.3'
+VERSION = '0.0.4'


### PR DESCRIPTION
The `require-push-to-pr` action was updated to output a string boolean indicating if it passed instead of failing. This PR updates our workspace to handle those changes.