### PR TITLE
Fix version action input path

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -19,7 +19,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version-regex-pattern: >
             VERSION = [\\'\\"](.+?)[\\'\\"]
-          version-file-path: 'version.py'
+          version-file-path: 'oapispec/version.py'
   publish-to-test-pypi:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The `require-semver-bumb` action was updated to fix the path input parameter. This change is to match that by making our input path be absolute from the project root.